### PR TITLE
Add X-Relay-ActivityHost Header.

### DIFF
--- a/handle.go
+++ b/handle.go
@@ -74,6 +74,7 @@ func contains(entries interface{}, finder string) bool {
 
 func pushRelayJob(sourceInbox string, body []byte) {
 	for _, domain := range relayState.Subscriptions {
+		sourceURL, _ := url.Parse(sourceInbox)
 		if sourceInbox != domain.Domain {
 			job := &tasks.Signature{
 				Name:       "relay",
@@ -88,6 +89,11 @@ func pushRelayJob(sourceInbox string, body []byte) {
 						Name:  "body",
 						Type:  "string",
 						Value: string(body),
+					},
+					{
+						Name:  "activityHost",
+						Type:  "string",
+						Value: sourceURL.Host,
 					},
 				},
 			}

--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,9 @@ See [GitHub wiki](https://github.com/yukimochi/Activity-Relay/wiki)
  - `RELAY_BIND` (ex. `0.0.0.0:8080`)
  - `REDIS_URL` (ex. `redis://127.0.0.1:6379/0`)
 
+## Appended HTTP Header
+
+ - `X-Relay-ActivityHost` Indicates an activity domain.
 
 ## License
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fyukimochi%2FActivity-Relay.svg?type=large)](https://app.fossa.io/projects/git%2Bgithub.com%2Fyukimochi%2FActivity-Relay?ref=badge_large)

--- a/worker/sender.go
+++ b/worker/sender.go
@@ -32,11 +32,14 @@ func appendSignature(request *http.Request, body *[]byte, KeyID string, publicKe
 	return nil
 }
 
-func sendActivity(inboxURL string, KeyID string, body []byte, publicKey *rsa.PrivateKey) error {
+func sendActivity(inboxURL string, KeyID string, body []byte, publicKey *rsa.PrivateKey, activityHost *string) error {
 	req, _ := http.NewRequest("POST", inboxURL, bytes.NewBuffer(body))
 	req.Header.Set("Content-Type", "application/activity+json, application/ld+json")
 	req.Header.Set("User-Agent", uaString)
 	req.Header.Set("Date", httpdate.Time2Str(time.Now()))
+	if activityHost != nil {
+		req.Header.Set("X-Relay-ActivityHost", *activityHost)
+	}
 	appendSignature(req, &body, KeyID, publicKey)
 	client := &http.Client{Timeout: time.Duration(5) * time.Second}
 	resp, err := client.Do(req)

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -29,7 +29,8 @@ var uaString string
 func relayActivity(args ...string) error {
 	inboxURL := args[0]
 	body := args[1]
-	err := sendActivity(inboxURL, Actor.ID, []byte(body), hostPrivatekey)
+	activityHost := args[2]
+	err := sendActivity(inboxURL, Actor.ID, []byte(body), hostPrivatekey, &activityHost)
 	if err != nil {
 		domain, _ := url.Parse(inboxURL)
 		mod, _ := redisClient.HSetNX("relay:statistics:"+domain.Host, "last_error", err.Error()).Result()
@@ -43,7 +44,7 @@ func relayActivity(args ...string) error {
 func registorActivity(args ...string) error {
 	inboxURL := args[0]
 	body := args[1]
-	err := sendActivity(inboxURL, Actor.ID, []byte(body), hostPrivatekey)
+	err := sendActivity(inboxURL, Actor.ID, []byte(body), hostPrivatekey, nil)
 	return err
 }
 

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -36,7 +36,7 @@ func TestRelayActivity(t *testing.T) {
 	}))
 	defer s.Close()
 
-	err := relayActivity(s.URL, "data")
+	err := relayActivity(s.URL, "data", "")
 	if err != nil {
 		t.Fatal("Failed - Data transfar not collect")
 	}
@@ -48,7 +48,7 @@ func TestRelayActivityNoHost(t *testing.T) {
 	}))
 	defer s.Close()
 
-	err := relayActivity("http://nohost.example.jp", "data")
+	err := relayActivity("http://nohost.example.jp", "data", "")
 	if err == nil {
 		t.Fatal("Failed - Error not reported.")
 	}
@@ -66,7 +66,7 @@ func TestRelayActivityResp500(t *testing.T) {
 	}))
 	defer s.Close()
 
-	err := relayActivity(s.URL, "data")
+	err := relayActivity(s.URL, "data", "")
 	if err == nil {
 		t.Fatal("Failed - Error not reported.")
 	}


### PR DESCRIPTION
Use only in v0.2.x. Alternate way to control statuses processing.