### PR TITLE
Fix docker-compose config location

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - "REDIS_URL=redis://redis:6379"
     volumes:
       - "./actor.pem:/actor.pem"
-      # - "./config.yaml:/Activity-Relay/config.yaml"
+      # - "./config.yaml:/config.yaml"
     depends_on:
       - redis
 
@@ -40,6 +40,6 @@ services:
       - "REDIS_URL=redis://redis:6379"
     volumes:
       - "./actor.pem:/actor.pem"
-      # - "./config.yaml:/Activity-Relay/config.yaml"
+      # - "./config.yaml:/config.yaml"
     depends_on:
       - redis


### PR DESCRIPTION
For those who are using docker-compose, the working directory is `/` not `/Activity-Relay/`. You can try it with docker-compose.