### PR TITLE
Add Makefile and Caddy config generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,9 @@
 .ionide
 
 # End of https://www.toptal.com/developers/gitignore/api/go,visualstudiocode
+
+actor.pem
+relay
+config.yml
+.conf_*
+Caddyfile

--- a/Caddyfile.tmpl
+++ b/Caddyfile.tmpl
@@ -1,0 +1,16 @@
+__HOSTNAME__ {
+  root * __WEBROOT__
+  file_server
+  encode gzip
+  # These paths are taken from api/api.go, and should be updated
+  # here if ever changed
+  reverse_proxy /.well-known/nodeinfo localhost:__APIPORT__
+  reverse_proxy /.well-known/webfinger localhost:__APIPORT__
+  reverse_proxy /nodeinfo/2.1 localhost:__APIPORT__
+  reverse_proxy /actor localhost:__APIPORT__
+  reverse_proxy /inbox localhost:__APIPORT__
+
+  php_fastcgi 127.0.0.1:9000
+
+}
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,80 @@
+SHELL=/bin/bash
+VERS=$(shell git describe --tags HEAD)
+
+.PHONY: all
+all: actor.pem config.yml relay Caddyfile
+	@echo Things and stuff
+
+.PHONY: setup
+setup: genconf
+
+.PHONY: genconf
+genconf: config.yml
+
+config.yml: .conf_redis .conf_domain .conf_desc config.yml.example | /var/lib/relay/actor.pem
+	@sed \
+		-e 's/^REDIS_URL:.*/REDIS_URL: redis:\/\/$(shell cat .conf_redis):6379/' \
+		-e 's/^RELAY_DOMAIN:.*/RELAY_DOMAIN: $(shell cat .conf_domain)/' \
+		-e "s/^RELAY_SERVICENAME:.*/RELAY_SERVICENAME: $(shell cat .conf_desc)/" < config.yml.example > $@
+
+.conf_redis:
+	@read -e -p "Redis host? [127.0.0.1] " r; \
+                R=$$(echo $$r | tr '[:upper:]' '[:lower:]'); \
+                if [ ! "$$R" ]; then \
+			R="127.0.0.1"; \
+                fi; echo "$$R" > $@
+
+.conf_domain:
+	@read -e -p "Relay Domain? [relay.wig.gl] " r; \
+                R=$$(echo $$r | tr '[:upper:]' '[:lower:]'); \
+                if [ ! "$$R" ]; then \
+			R="relay.wig.gl"; \
+                fi; echo "$$R" > $@
+
+.conf_desc:
+	@read -e -p "Description? [Honest Rob's Relay] " r; \
+                R=$$(echo $$r | tr -d '"'); \
+                if [ ! "$$R" ]; then \
+			R="'Honest' Rob's Relay"; \
+                fi; echo "$$R" > $@
+
+WEBROOT = /var/lib/relay/webroot
+APIPORT = $(shell awk -F: '/^RELAY_BIND:/ { print $$3 }' config.yml)
+HOSTNAME = $(shell cat .conf_domain)
+
+.PHONY: caddyfile
+caddyfile: /etc/caddy/Caddyfile
+
+/etc/caddy/Caddyfile: Caddyfile
+	@if [ ! -d /etc/caddy ]; then echo "/etc/caddy not present, can not continue"; exit 1; fi
+	@cp $< $@ && echo "Restarting caddy service" && systemctl restart caddy
+
+Caddyfile: Caddyfile.tmpl config.yml $(WEBROOT)
+	@sed -e 's!__WEBROOT__!$(WEBROOT)!' -e 's/__APIPORT__/$(APIPORT)/' -e 's/__HOSTNAME__/$(HOSTNAME)/' < Caddyfile.tmpl > $@
+
+relay: $(wildcard **/*go)
+	go build -o $@ -ldflags "-X main.version=$(VERS)" .
+
+$(WEBROOT):
+	@mkdir -p $(WEBROOT)
+	@cp webroot/index.html $(WEBROOT)/index.html
+	@chown -R relay.relay $(WEBROOT)
+
+actor.pem: | /usr/bin/openssl
+	/usr/bin/openssl genrsa -traditional > $@
+	chmod 600 $@
+
+/var/lib/relay/actor.pem: actor.pem | /var/lib/relay
+	cp $< $@
+	chown relay.relay $@
+	chmod 600 $@
+
+/var/lib/relay:
+	groupadd --system relay
+	useradd --system --gid relay --create-home --home-dir /var/lib/relay --shell /usr/sbin/nologin --comment "YUKIMOCHI Activity-Relay" relay
+	chmod 755 /var/lib/relay
+	passwd -l relay
+
+/usr/bin/openssl:
+	@echo "Can't continue - please install openssl"
+	@exit 1

--- a/api/handle.go
+++ b/api/handle.go
@@ -3,9 +3,10 @@ package api
 import (
 	"encoding/json"
 	"errors"
-	uuid "github.com/satori/go.uuid"
 	"net/http"
 	"net/url"
+
+	uuid "github.com/satori/go.uuid"
 
 	"github.com/RichardKnop/machinery/v1/tasks"
 	"github.com/sirupsen/logrus"
@@ -308,7 +309,8 @@ func handleInbox(writer http.ResponseWriter, request *http.Request, activityDeco
 			}
 		}
 	default:
+		writer.Header().Add("Content-Type", "text/plain")
 		writer.WriteHeader(404)
-		writer.Write(nil)
+		writer.Write([]byte("This interface is not for humans, please add this URL as a relay"))
 	}
 }

--- a/config.yml.example
+++ b/config.yml.example
@@ -5,7 +5,7 @@ RELAY_BIND: 127.0.0.1:8080
 RELAY_DOMAIN: relay.toot.yukimochi.jp
 RELAY_SERVICENAME: YUKIMOCHI Toot Relay Service
 JOB_CONCURRENCY: 50
-RELAY_SUMMARY: Taken from https://git.artemai.art/xrobau/Activity-Relay
+RELAY_SUMMARY: Taken from https://github.com/yukimochi/Activity-Relay
 
 # RELAY_ICON: https://
 # RELAY_IMAGE: https://

--- a/config.yml.example
+++ b/config.yml.example
@@ -1,11 +1,11 @@
 ACTOR_PEM: /var/lib/relay/actor.pem
 REDIS_URL: redis://redis:6379
 
-RELAY_BIND: 0.0.0.0:8080
+RELAY_BIND: 127.0.0.1:8080
 RELAY_DOMAIN: relay.toot.yukimochi.jp
 RELAY_SERVICENAME: YUKIMOCHI Toot Relay Service
 JOB_CONCURRENCY: 50
-# RELAY_SUMMARY: |
+RELAY_SUMMARY: Taken from https://git.artemai.art/xrobau/Activity-Relay
 
 # RELAY_ICON: https://
 # RELAY_IMAGE: https://

--- a/webroot/index.html
+++ b/webroot/index.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>YUKIMOCHI Activity-Relay</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
+  </head>
+<body>
+	<div class='container text-center'>
+		<div class='row'>
+			<div class='col'>
+				<h1>YUKIMOCHI Activity-Relay</h1>
+			</div>
+		</div>
+		<div class='row'>
+			<div class='col'>
+				<p>This is an unconfigured instance. These files are located in /var/lib/relay/webroot</p>
+			</div>
+		</div>
+	</div>
+	<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-kenU1KFdBIe4zVF0s0G1M5b4hcpxyD9F7jL+jjXkk+Q2h455rYXK/7HAuoJl+0I4" crossorigin="anonymous"></script>
+</body>
+</html>
+


### PR DESCRIPTION
    This adds some tools and helpers to make deploying a new instance
    easier. I also encourage the use of Caddy, which allows reverse
    proxy of the required paths, and a simple webserver for anything
    that doesn't match anything known about by the API instance.

    There is a very simple index.html which is copied to the webroot
    folder (/var/lib/relay/webroot) which the end user can then modify
    if wanted.

    This consists of squashed commits:
        Put the default webroot in a sensible location
        Add a slightly better 404 string
        Add caddyfile generator
        Add config hooks
        Add basic Makefile

    See https://git.artemai.art/xrobau/Activity-Relay for raw commits

    Signed-Off-By: Rob Thomas <xrobau@gmail.com>

