### PR TITLE
feat: align version string to nodeinfo schema format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY . /Activity-Relay
 
 RUN  mkdir -p /rootfs/usr/bin && \
      apk add -U --no-cache git && \
-     go build -o /rootfs/usr/bin/relay -ldflags "-X main.version=$(git describe --tags HEAD)" .
+     go build -o /rootfs/usr/bin/relay -ldflags "-X main.version=$(git describe --tags HEAD | sed -r 's/v(.*)/\1/')" .
 
 FROM alpine:3.17.2
 

--- a/main.go
+++ b/main.go
@@ -59,7 +59,7 @@ import (
 )
 
 var (
-	version string
+	version = "devel"
 	verbose bool
 
 	GlobalConfig *models.RelayConfig

--- a/models/config_test.go
+++ b/models/config_test.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"strconv"
 	"strings"
 	"testing"
 
@@ -85,11 +86,12 @@ func TestRelayConfig_DumpWelcomeMessage(t *testing.T) {
 	w := relayConfig.DumpWelcomeMessage("Testing", "")
 
 	informations := map[string]string{
-		"module NAME":  "Testing",
-		"RELAY NAME":   relayConfig.serviceName,
-		"RELAY DOMAIN": relayConfig.domain.Host,
-		"REDIS URL":    relayConfig.redisURL,
-		"BIND ADDRESS": relayConfig.serverBind,
+		"module NAME":     "Testing",
+		"RELAY NAME":      relayConfig.serviceName,
+		"RELAY DOMAIN":    relayConfig.domain.Host,
+		"REDIS URL":       relayConfig.redisURL,
+		"BIND ADDRESS":    relayConfig.serverBind,
+		"JOB_CONCURRENCY": strconv.Itoa(relayConfig.jobConcurrency),
 	}
 
 	for key, information := range informations {


### PR DESCRIPTION
- nodeinfo don't need `v` in version string
- Appendix: Changed version default string from empty to "devel"