### PR TITLE
Update Alpine to fix a numer of CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN  mkdir -p /rootfs/usr/bin && \
      apk add -U --no-cache git && \
      go build -o /rootfs/usr/bin/relay -ldflags "-X main.version=$(git describe --tags HEAD | sed -r 's/v(.*)/\1/')" .
 
-FROM alpine:3.17.2
+FROM alpine:3.18.2
 
 COPY --from=build /rootfs/usr/bin /usr/bin
 RUN  chmod +x /usr/bin/relay && \


### PR DESCRIPTION
This is a tiny PR just updating the version of Alpine.

There are a number of flagged CVEs in alpine 3.17.2:
````
ghcr.io/yukimochi/activity-relay/activity-relay:v2.0.2 (alpine 3.17.2)

Total: 10 (UNKNOWN: 0, LOW: 0, MEDIUM: 6, HIGH: 4, CRITICAL: 0)

┌────────────┬───────────────┬──────────┬───────────────────┬───────────────┬────────────────────────────────────────────────────────────┐
│  Library   │ Vulnerability │ Severity │ Installed Version │ Fixed Version │                           Title                            │
├────────────┼───────────────┼──────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────────┤
│ libcrypto3 │ CVE-2023-0464 │ HIGH     │ 3.0.8-r0          │ 3.0.8-r1      │ Denial of service by excessive resource usage in verifying │
│            │               │          │                   │               │ X509 policy constraints...                                 │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0464                  │
│            ├───────────────┤          │                   ├───────────────┼────────────────────────────────────────────────────────────┤
│            │ CVE-2023-2650 │          │                   │ 3.0.9-r0      │ Possible DoS translating ASN.1 object identifiers          │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-2650                  │
│            ├───────────────┼──────────┤                   ├───────────────┼────────────────────────────────────────────────────────────┤
│            │ CVE-2023-0465 │ MEDIUM   │                   │ 3.0.8-r2      │ Invalid certificate policies in leaf certificates are      │
│            │               │          │                   │               │ silently ignored                                           │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0465                  │
│            ├───────────────┤          │                   ├───────────────┼────────────────────────────────────────────────────────────┤
│            │ CVE-2023-0466 │          │                   │ 3.0.8-r3      │ Certificate policy check not enabled                       │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0466                  │
│            ├───────────────┤          │                   ├───────────────┼────────────────────────────────────────────────────────────┤
│            │ CVE-2023-1255 │          │                   │ 3.0.8-r4      │ Input buffer over-read in AES-XTS implementation on 64 bit │
│            │               │          │                   │               │ ARM                                                        │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-1255                  │
├────────────┼───────────────┼──────────┤                   ├───────────────┼────────────────────────────────────────────────────────────┤
│ libssl3    │ CVE-2023-0464 │ HIGH     │                   │ 3.0.8-r1      │ Denial of service by excessive resource usage in verifying │
│            │               │          │                   │               │ X509 policy constraints...                                 │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0464                  │
│            ├───────────────┤          │                   ├───────────────┼────────────────────────────────────────────────────────────┤
│            │ CVE-2023-2650 │          │                   │ 3.0.9-r0      │ Possible DoS translating ASN.1 object identifiers          │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-2650                  │
│            ├───────────────┼──────────┤                   ├───────────────┼────────────────────────────────────────────────────────────┤
│            │ CVE-2023-0465 │ MEDIUM   │                   │ 3.0.8-r2      │ Invalid certificate policies in leaf certificates are      │
│            │               │          │                   │               │ silently ignored                                           │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0465                  │
│            ├───────────────┤          │                   ├───────────────┼────────────────────────────────────────────────────────────┤
│            │ CVE-2023-0466 │          │                   │ 3.0.8-r3      │ Certificate policy check not enabled                       │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-0466                  │
│            ├───────────────┤          │                   ├───────────────┼────────────────────────────────────────────────────────────┤
│            │ CVE-2023-1255 │          │                   │ 3.0.8-r4      │ Input buffer over-read in AES-XTS implementation on 64 bit │
│            │               │          │                   │               │ ARM                                                        │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-1255                  │
└────────────┴───────────────┴──────────┴───────────────────┴───────────────┴────────────────────────────────────────────────────────────┘

````