### PR TITLE
Update docker image to address some CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.6-alpine AS build
+FROM golang:1.22.5-alpine AS build
 
 WORKDIR /Activity-Relay
 COPY . /Activity-Relay
@@ -7,7 +7,7 @@ RUN  mkdir -p /rootfs/usr/bin && \
      apk add -U --no-cache git && \
      go build -o /rootfs/usr/bin/relay -ldflags "-X main.version=$(git describe --tags HEAD | sed -r 's/v(.*)/\1/')" .
 
-FROM alpine:3.19.1
+FROM alpine:3.20.2
 
 COPY --from=build /rootfs/usr/bin /usr/bin
 RUN  chmod +x /usr/bin/relay && \


### PR DESCRIPTION
Trivy is flagging some vulnerabilities present in the docker image. This is a tiny PR to clear them.

```
ghcr.io/yukimochi/activity-relay/activity-relay:v2.0.5 (alpine 3.19.1)

Total: 20 (UNKNOWN: 0, LOW: 2, MEDIUM: 18, HIGH: 0, CRITICAL: 0)

┌───────────────┬────────────────┬──────────┬────────┬───────────────────┬───────────────┬───────────────────────────────────────────────────────────┐
│    Library    │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version │                           Title                           │
├───────────────┼────────────────┼──────────┼────────┼───────────────────┼───────────────┼───────────────────────────────────────────────────────────┤
│ busybox       │ CVE-2023-42363 │ MEDIUM   │ fixed  │ 1.36.1-r15        │ 1.36.1-r17    │ busybox: use-after-free in awk                            │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-42363                │
│               ├────────────────┤          │        │                   ├───────────────┼───────────────────────────────────────────────────────────┤
│               │ CVE-2023-42364 │          │        │                   │ 1.36.1-r19    │ busybox: use-after-free                                   │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-42364                │
│               ├────────────────┤          │        │                   │               ├───────────────────────────────────────────────────────────┤
│               │ CVE-2023-42365 │          │        │                   │               │ busybox: use-after-free                                   │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-42365                │
│               ├────────────────┤          │        │                   ├───────────────┼───────────────────────────────────────────────────────────┤
│               │ CVE-2023-42366 │          │        │                   │ 1.36.1-r16    │ busybox: A heap-buffer-overflow                           │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-42366                │
├───────────────┼────────────────┤          │        │                   ├───────────────┼───────────────────────────────────────────────────────────┤
│ busybox-binsh │ CVE-2023-42363 │          │        │                   │ 1.36.1-r17    │ busybox: use-after-free in awk                            │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-42363                │
│               ├────────────────┤          │        │                   ├───────────────┼───────────────────────────────────────────────────────────┤
│               │ CVE-2023-42364 │          │        │                   │ 1.36.1-r19    │ busybox: use-after-free                                   │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-42364                │
│               ├────────────────┤          │        │                   │               ├───────────────────────────────────────────────────────────┤
│               │ CVE-2023-42365 │          │        │                   │               │ busybox: use-after-free                                   │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-42365                │
│               ├────────────────┤          │        │                   ├───────────────┼───────────────────────────────────────────────────────────┤
│               │ CVE-2023-42366 │          │        │                   │ 1.36.1-r16    │ busybox: A heap-buffer-overflow                           │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-42366                │
├───────────────┼────────────────┤          │        ├───────────────────┼───────────────┼───────────────────────────────────────────────────────────┤
│ libcrypto3    │ CVE-2024-4603  │          │        │ 3.1.4-r5          │ 3.1.5-r0      │ openssl: Excessive time spent checking DSA keys and       │
│               │                │          │        │                   │               │ parameters                                                │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-4603                 │
│               ├────────────────┤          │        │                   ├───────────────┼───────────────────────────────────────────────────────────┤
│               │ CVE-2024-4741  │          │        │                   │ 3.1.6-r0      │ openssl: Use After Free with SSL_free_buffers             │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-4741                 │
│               ├────────────────┤          │        │                   │               ├───────────────────────────────────────────────────────────┤
│               │ CVE-2024-5535  │          │        │                   │               │ openssl: SSL_select_next_proto buffer overread            │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-5535                 │
│               ├────────────────┼──────────┤        │                   ├───────────────┼───────────────────────────────────────────────────────────┤
│               │ CVE-2024-2511  │ LOW      │        │                   │ 3.1.4-r6      │ openssl: Unbounded memory growth with session handling in │
│               │                │          │        │                   │               │ TLSv1.3                                                   │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-2511                 │
├───────────────┼────────────────┼──────────┤        │                   ├───────────────┼───────────────────────────────────────────────────────────┤
│ libssl3       │ CVE-2024-4603  │ MEDIUM   │        │                   │ 3.1.5-r0      │ openssl: Excessive time spent checking DSA keys and       │
│               │                │          │        │                   │               │ parameters                                                │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-4603                 │
│               ├────────────────┤          │        │                   ├───────────────┼───────────────────────────────────────────────────────────┤
│               │ CVE-2024-4741  │          │        │                   │ 3.1.6-r0      │ openssl: Use After Free with SSL_free_buffers             │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-4741                 │
│               ├────────────────┤          │        │                   │               ├───────────────────────────────────────────────────────────┤
│               │ CVE-2024-5535  │          │        │                   │               │ openssl: SSL_select_next_proto buffer overread            │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-5535                 │
│               ├────────────────┼──────────┤        │                   ├───────────────┼───────────────────────────────────────────────────────────┤
│               │ CVE-2024-2511  │ LOW      │        │                   │ 3.1.4-r6      │ openssl: Unbounded memory growth with session handling in │
│               │                │          │        │                   │               │ TLSv1.3                                                   │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-2511                 │
├───────────────┼────────────────┼──────────┤        ├───────────────────┼───────────────┼───────────────────────────────────────────────────────────┤
│ ssl_client    │ CVE-2023-42363 │ MEDIUM   │        │ 1.36.1-r15        │ 1.36.1-r17    │ busybox: use-after-free in awk                            │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-42363                │
│               ├────────────────┤          │        │                   ├───────────────┼───────────────────────────────────────────────────────────┤
│               │ CVE-2023-42364 │          │        │                   │ 1.36.1-r19    │ busybox: use-after-free                                   │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-42364                │
│               ├────────────────┤          │        │                   │               ├───────────────────────────────────────────────────────────┤
│               │ CVE-2023-42365 │          │        │                   │               │ busybox: use-after-free                                   │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-42365                │
│               ├────────────────┤          │        │                   ├───────────────┼───────────────────────────────────────────────────────────┤
│               │ CVE-2023-42366 │          │        │                   │ 1.36.1-r16    │ busybox: A heap-buffer-overflow                           │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-42366                │
└───────────────┴────────────────┴──────────┴────────┴───────────────────┴───────────────┴───────────────────────────────────────────────────────────┘

usr/bin/relay (gobinary)

Total: 9 (UNKNOWN: 0, LOW: 0, MEDIUM: 7, HIGH: 1, CRITICAL: 1)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬─────────────────┬──────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version  │                            Title                             │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼─────────────────┼──────────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2024-24790 │ CRITICAL │ fixed  │ 1.21.6            │ 1.21.11, 1.22.4 │ golang: net/netip: Unexpected behavior from Is methods for   │
│         │                │          │        │                   │                 │ IPv4-mapped IPv6 addresses                                   │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-24790                   │
│         ├────────────────┼──────────┤        │                   ├─────────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2023-45288 │ HIGH     │        │                   │ 1.21.9, 1.22.2  │ golang: net/http, x/net/http2: unlimited number of           │
│         │                │          │        │                   │                 │ CONTINUATION frames causes DoS                               │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2023-45288                   │
│         ├────────────────┼──────────┤        │                   ├─────────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2023-45289 │ MEDIUM   │        │                   │ 1.21.8, 1.22.1  │ golang: net/http/cookiejar: incorrect forwarding of          │
│         │                │          │        │                   │                 │ sensitive headers and cookies on HTTP redirect...            │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2023-45289                   │
│         ├────────────────┤          │        │                   │                 ├──────────────────────────────────────────────────────────────┤
│         │ CVE-2023-45290 │          │        │                   │                 │ golang: net/http: memory exhaustion in                       │
│         │                │          │        │                   │                 │ Request.ParseMultipartForm                                   │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2023-45290                   │
│         ├────────────────┤          │        │                   │                 ├──────────────────────────────────────────────────────────────┤
│         │ CVE-2024-24783 │          │        │                   │                 │ golang: crypto/x509: Verify panics on certificates with an   │
│         │                │          │        │                   │                 │ unknown public key algorithm...                              │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-24783                   │
│         ├────────────────┤          │        │                   │                 ├──────────────────────────────────────────────────────────────┤
│         │ CVE-2024-24784 │          │        │                   │                 │ golang: net/mail: comments in display names are incorrectly  │
│         │                │          │        │                   │                 │ handled                                                      │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-24784                   │
│         ├────────────────┤          │        │                   │                 ├──────────────────────────────────────────────────────────────┤
│         │ CVE-2024-24785 │          │        │                   │                 │ golang: html/template: errors returned from MarshalJSON      │
│         │                │          │        │                   │                 │ methods may break template escaping                          │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-24785                   │
│         ├────────────────┤          │        │                   ├─────────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2024-24789 │          │        │                   │ 1.21.11, 1.22.4 │ golang: archive/zip: Incorrect handling of certain ZIP files │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-24789                   │
│         ├────────────────┤          │        │                   ├─────────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2024-24791 │          │        │                   │ 1.21.12, 1.22.5 │ net/http: Denial of service due to improper 100-continue     │
│         │                │          │        │                   │                 │ handling in net/http                                         │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-24791                   │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴─────────────────┴──────────────────────────────────────────────────────────────┘
```

