### PR TITLE
fix: use correct key ID in HTTP signatures

### DIFF
--- a/deliver/deliver.go
+++ b/deliver/deliver.go
@@ -35,7 +35,7 @@ func relayActivityV2(args ...string) error {
 		return errors.New("activity ttl expired")
 	}
 
-	err = sendActivity(inboxURL, RelayActor.ID, []byte(body), GlobalConfig.ActorKey())
+	err = sendActivity(inboxURL, RelayActor.PublicKey.ID, []byte(body), GlobalConfig.ActorKey())
 	if err != nil {
 		domain, _ := url.Parse(inboxURL)
 		pushErrorLogScript := "local change = redis.call('HSETNX', KEYS[1], 'last_error', ARGV[1]); if change == 1 then redis.call('EXPIRE', KEYS[1], ARGV[2]) end;"
@@ -49,7 +49,7 @@ func relayActivityV2(args ...string) error {
 func registerActivity(args ...string) error {
 	inboxURL := args[0]
 	body := args[1]
-	err := sendActivity(inboxURL, RelayActor.ID, []byte(body), GlobalConfig.ActorKey())
+	err := sendActivity(inboxURL, RelayActor.PublicKey.ID, []byte(body), GlobalConfig.ActorKey())
 	return err
 }
 


### PR DESCRIPTION
Previously, the relay was using its actor ID (`/actor`) as the key ID in HTTP signatures while advertising a different key ID (`/actor#main-key`) in its actor document. This mismatch breaks compatibility with ActivityPub servers that expect a 1:1 mapping between signing key IDs and public key IDs.

Changes:

- Updated `relayActivityV2` and `registerActivity` to use `RelayActor.PublicKey.ID` instead of `RelayActor.ID` when signing requests
- This ensures HTTP signatures use the same key ID that is advertised in the actor's public key field

Fixes issue where some servers reject activities due to key ID mismatch.

Issues:

- #96
- https://akkoma.dev/AkkomaGang/akkoma/issues/858#issuecomment-13758