### PR TITLE
chore: add missing defer file statements, use modern syntax in utils.go

### DIFF
--- a/control/domain_test.go
+++ b/control/domain_test.go
@@ -13,10 +13,13 @@ func TestListDomainSubscriber(t *testing.T) {
 	RelayState.RedisClient.FlushAll(context.TODO()).Result()
 
 	app := configCmdInit()
+
 	file, err := os.Open("../misc/test/exampleConfig.json")
 	if err != nil {
 		t.Fatalf("Failed to open test resource file: %v", err)
 	}
+	defer file.Close()
+
 	jsonData, _ := io.ReadAll(file)
 
 	app.SetArgs([]string{"import", "--data", string(jsonData)})
@@ -45,10 +48,13 @@ func TestListDomainLimited(t *testing.T) {
 	RelayState.RedisClient.FlushAll(context.TODO()).Result()
 
 	app := configCmdInit()
+
 	file, err := os.Open("../misc/test/exampleConfig.json")
 	if err != nil {
 		t.Fatalf("Failed to open test resource file: %v", err)
 	}
+	defer file.Close()
+
 	jsonData, _ := io.ReadAll(file)
 
 	app.SetArgs([]string{"import", "--data", string(jsonData)})
@@ -76,10 +82,13 @@ func TestListDomainBlocked(t *testing.T) {
 	RelayState.RedisClient.FlushAll(context.TODO()).Result()
 
 	app := configCmdInit()
+
 	file, err := os.Open("../misc/test/exampleConfig.json")
 	if err != nil {
 		t.Fatalf("Failed to open test resource file: %v", err)
 	}
+	defer file.Close()
+
 	jsonData, _ := io.ReadAll(file)
 
 	app.SetArgs([]string{"import", "--data", string(jsonData)})
@@ -149,10 +158,13 @@ func TestUnsetDomainBlocked(t *testing.T) {
 	RelayState.RedisClient.FlushAll(context.TODO()).Result()
 
 	app := configCmdInit()
+
 	file, err := os.Open("../misc/test/exampleConfig.json")
 	if err != nil {
 		t.Fatalf("Failed to open test resource file: %v", err)
 	}
+	defer file.Close()
+
 	jsonData, _ := io.ReadAll(file)
 
 	app.SetArgs([]string{"import", "--data", string(jsonData)})
@@ -179,10 +191,13 @@ func TestUnsetDomainLimited(t *testing.T) {
 	RelayState.RedisClient.FlushAll(context.TODO()).Result()
 
 	app := configCmdInit()
+
 	file, err := os.Open("../misc/test/exampleConfig.json")
 	if err != nil {
 		t.Fatalf("Failed to open test resource file: %v", err)
 	}
+	defer file.Close()
+
 	jsonData, _ := io.ReadAll(file)
 
 	app.SetArgs([]string{"import", "--data", string(jsonData)})
@@ -209,10 +224,13 @@ func TestSetDomainInvalid(t *testing.T) {
 	RelayState.RedisClient.FlushAll(context.TODO()).Result()
 
 	app := configCmdInit()
+
 	file, err := os.Open("../misc/test/exampleConfig.json")
 	if err != nil {
 		t.Fatalf("Failed to open test resource file: %v", err)
 	}
+	defer file.Close()
+
 	jsonData, _ := io.ReadAll(file)
 
 	app.SetArgs([]string{"import", "--data", string(jsonData)})
@@ -236,10 +254,13 @@ func TestUnfollowDomain(t *testing.T) {
 	RelayState.RedisClient.FlushAll(context.TODO()).Result()
 
 	app := configCmdInit()
+
 	file, err := os.Open("../misc/test/exampleConfig.json")
 	if err != nil {
 		t.Fatalf("Failed to open test resource file: %v", err)
 	}
+	defer file.Close()
+
 	jsonData, _ := io.ReadAll(file)
 
 	app.SetArgs([]string{"import", "--data", string(jsonData)})
@@ -266,10 +287,13 @@ func TestInvalidUnfollowDomain(t *testing.T) {
 	RelayState.RedisClient.FlushAll(context.TODO()).Result()
 
 	app := configCmdInit()
+
 	file, err := os.Open("../misc/test/exampleConfig.json")
 	if err != nil {
 		t.Fatalf("Failed to open test resource file: %v", err)
 	}
+	defer file.Close()
+
 	jsonData, _ := io.ReadAll(file)
 
 	app.SetArgs([]string{"import", "--data", string(jsonData)})

--- a/control/utils.go
+++ b/control/utils.go
@@ -1,27 +1,24 @@
 package control
 
+import "slices"
+
 import "github.com/yukimochi/Activity-Relay/models"
 
-func contains(entries interface{}, key string) bool {
+func contains(entries any, key string) bool {
 	switch entry := entries.(type) {
 	case string:
 		return entry == key
 	case []string:
-		for i := 0; i < len(entry); i++ {
-			if entry[i] == key {
-				return true
-			}
-		}
-		return false
+		return slices.Contains(entry, key)
 	case []models.Subscriber:
-		for i := 0; i < len(entry); i++ {
+		for i := range entry {
 			if entry[i].Domain == key {
 				return true
 			}
 		}
 		return false
 	case []models.Follower:
-		for i := 0; i < len(entry); i++ {
+		for i := range entry {
 			if entry[i].Domain == key {
 				return true
 			}


### PR DESCRIPTION
Hi,

I've added some missing `defer file.Close()` to `control/domain_test.go` and also saw that some loop iteration expressions were outdated, see `control/utils.go`.

I've read through the source code to understand how `Activity-Relay` works.

I'm still not sure if it would work for my usecase though!

I'd like to setup my own private relay where I define like 5-10 instances that should be relayed to my `GoToSocial` instance. Is it possible to configure `Activity-Relay` with only a predefined set of instances that should be relayed?

Thanks!